### PR TITLE
API_DrawLevel, API_DrawPanel and API_Turns

### DIFF
--- a/APIs/API_Disrupt/API_Disrupt.py
+++ b/APIs/API_Disrupt/API_Disrupt.py
@@ -1,3 +1,4 @@
+import Level
 
 def disrupt_default(self, caster):
 	self.level_gen_params = caster.level.gen_params.make_child_generator()

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -1,0 +1,423 @@
+import Level
+import CommonContent
+#import RiftWizard
+import Spells
+import pygame
+from collections import namedtuple
+from typing import Dict, List, Set
+
+####################################################
+# Importing RiftWizard.py                          |
+# Credit to trung on discord                       |
+#                                                  |
+#----------------------------------------------    |
+import inspect #                                   |
+def get_RiftWizard(): #                            |
+    # Returns the RiftWizard.py module object      |
+    for f in inspect.stack()[::-1]: #              |
+        if "file 'RiftWizard.py'" in str(f): #     |
+            return inspect.getmodule(f[0]) #       |
+	 #                                             |
+    return inspect.getmodule(f[0]) #               |
+#                                                  |
+RiftWizard = get_RiftWizard() #                    |
+#                                                  |
+#                                                  |
+####################################################
+
+class Layer:
+    def __init__(self, order):
+        self.order = order
+        self.occluded_by: List[Layer] = []
+        self.view = None
+
+    ## Whether the layer should be drawn at all
+    def should_draw(self):
+        return True
+
+    ## Called when the layer should be drawn
+    def draw_layer(self):
+        pass
+
+    ## Called once for each tile before the layer is drawn
+    def accept_tile(self, tile):
+        pass
+
+    ## Called once before the layer accepts any tiles, allowing you to reset stored data
+    def reset(self):
+        pass
+
+    ## Whether a tile is occluded by this layer
+    def occludes(self, x, y):
+        return False
+
+    ## Checks whether a tile on this layer is occluded by another layer
+    def is_occluded(self, x, y):
+        return any(layer.occludes(x, y) for layer in self.occluded_by)
+
+    def __getattr__(self, attribute):
+        # Redirect accesses to 
+        return getattr(self.view, attribute)
+
+class LayerLOS (Layer):
+    def __init__(self):
+        super().__init__(500)
+
+    def should_draw(self):
+        keys = pygame.key.get_pressed()
+        return any(k and keys[k] for k in self.key_binds[RiftWizard.KEY_BIND_LOS])
+
+    def draw_layer(self):
+        self.draw_los()
+
+class LayerThreat (Layer):
+    def __init__(self):
+        super().__init__(500)
+
+    def should_draw(self):
+        keys = pygame.key.get_pressed()
+        return any(k and keys[k] for k in self.key_binds[RiftWizard.KEY_BIND_THREAT]) and self.game.is_awaiting_input()
+
+    def draw_layer(self):
+        self.draw_threat()
+
+class LayerSpellTarget (Layer):
+    def __init__(self):
+        super().__init__(500)
+
+    def should_draw(self):
+        return self.cur_spell
+
+    def draw_layer(self):	
+        self.draw_targeting()
+
+class LayerOrbTarget (Layer):
+    def __init__(self):
+        super().__init__(700)
+    
+    def draw_layer(self):
+        if isinstance(self.examine_target, Level.Unit):
+            buff = self.examine_target.get_buff(Spells.OrbBuff)
+            if buff and buff.dest:
+                dest = buff.dest
+                rect = (dest.x * RiftWizard.SPRITE_SIZE, dest.y * RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE)
+                self.level_display.blit(self.hostile_los_image, (dest.x * RiftWizard.SPRITE_SIZE, dest.y * RiftWizard.SPRITE_SIZE))
+
+class LayerChannelTarget (Layer):
+    def __init__(self):
+        super().__init__(50)
+    
+    def draw_layer(self):
+        if hasattr(self.examine_target, 'level') and hasattr(self.examine_target, 'x') and hasattr(self.examine_target, 'y'):
+            if isinstance(self.examine_target, Level.Unit) and self.examine_target.cur_hp > 0:
+                if self.examine_target.has_buff(Level.ChannelBuff):
+                    b = self.examine_target.get_buff(Level.ChannelBuff)             
+                    rect = (b.spell_target.x * RiftWizard.SPRITE_SIZE, b.spell_target.y * RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE)
+                    color = (60, 0, 0)
+                    # TODO- red target circle(or green if ally) instead of grey background block
+                    # TODO- all impacted tiles of target
+                    pygame.draw.rect(self.level_display, color, rect)
+
+class LayerSoulbound (Layer):
+    def __init__(self):
+        super().__init__(50)
+    
+    def draw_layer(self):
+        if hasattr(self.examine_target, 'level') and hasattr(self.examine_target, 'x') and hasattr(self.examine_target, 'y'):
+            if isinstance(self.examine_target, Level.Unit) and self.examine_target.cur_hp > 0:
+                if self.examine_target.has_buff(CommonContent.Soulbound):
+                    b = self.examine_target.get_buff(CommonContent.Soulbound)
+
+                    rect = (b.guardian.x * RiftWizard.SPRITE_SIZE, b.guardian.y * RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE)
+                    color = (60, 0, 0)
+                    pygame.draw.rect(self.level_display, color, rect)
+
+class LayerEffects (Layer):
+
+    def __init__(self):
+        super().__init__(800)
+        self.occlusion: Set = set()
+
+    def draw_layer(self):
+        for e in self.effects: 
+            if not self.is_occluded(e.x, e.y):
+                self.draw_effect(e)
+
+    def reset(self):
+        self.occlusion.clear()
+        for effect in self.effects:
+            self.occlusion.add((effect.x, effect.y))
+
+    def occludes(self, x, y):
+        return (x, y) in self.occlusion
+
+class LayerTiles (Layer):
+
+    def __init__(self):
+        super().__init__(100)
+        self.tiles: List[Level.Tile] = []
+        self.partially_occluded_by: List[Layer] = []
+        self.occlusion: Set = set()
+
+    def accept_tile(self, tile):
+        self.tiles.append(tile)
+        self.occlusion.add((tile.x, tile.y))
+
+    def draw_layer(self):
+        for tile in self.tiles:
+            should_draw_tile = True
+            if self.is_occluded(tile.x, tile.y, tile=tile):
+                should_draw_tile = False
+            if should_draw_tile:
+                partial_occulde = self.is_partially_occluded(tile.x, tile.y)
+                self.draw_tile(tile, partial_occulde=partial_occulde)
+
+    def reset(self):
+        self.tiles.clear()
+        self.occlusion.clear()
+
+    def is_occluded(self, x, y, tile=None):
+        if tile and not tile.is_chasm and LAYER_UNITS.occludes(x,y): # Tiles are also occluded by units if they're not chasmas
+            return True
+        return super().is_occluded(x, y)
+
+    def is_partially_occluded(self, x, y):
+        return any(layer.occludes(x, y) for layer in self.partially_occluded_by)
+
+    def occludes(self, x, y):
+        return (x, y) in self.occlusion
+
+class LayerProps (Layer):
+
+    def __init__(self):
+        super().__init__(120)
+        self.props: List[Level.Prop] = []
+        self.occlusion: Set = set()
+
+    def accept_tile(self, tile):
+        if tile.prop:
+            self.props.append(tile.prop)
+            self.occlusion.add((tile.x, tile.y))
+
+    def draw_layer(self):
+        for prop in self.props:
+            if not self.is_occluded(prop.x, prop.y):
+                self.draw_prop(prop)
+
+    def reset(self):
+        self.props.clear()
+        self.occlusion.clear()
+
+    def occludes(self, x, y):
+        return (x, y) in self.occlusion
+
+class LayerUnits (Layer):
+
+    def __init__(self):
+        super().__init__(150)
+        self.units: List[Level.Unit] = []
+        self.occlusion: Set = set()
+
+    def accept_tile(self, tile):
+        if tile.unit:
+            self.units.append(tile.unit)
+            self.occlusion.add((tile.x, tile.y))
+
+    def draw_layer(self):
+        for unit in self.units:
+            if not self.is_occluded(unit.x, unit.y):
+                self.draw_unit(unit)
+
+    def reset(self):
+        self.units.clear()
+        self.occlusion.clear()
+
+    def occludes(self, x, y):
+        return (x, y) in self.occlusion
+
+class LayerClouds (Layer):
+
+    def __init__(self):
+        super().__init__(200)
+        self.clouds: List[Level.Cloud] = []
+        self.occlusion: Set = set()
+
+    def accept_tile(self, tile):
+        if tile.cloud:
+            self.clouds.append(tile.cloud)
+            self.occlusion.add((tile.x, tile.y))
+
+    def draw_layer(self):
+        for cloud in self.clouds:
+            if not self.is_occluded(cloud.x, cloud.y):
+                self.draw_cloud(cloud)
+
+    def reset(self):
+        self.clouds.clear()
+        self.occlusion.clear()
+
+    def occludes(self, x, y):
+        return (x, y) in self.occlusion
+    
+class LayerDeploy (Layer):
+
+    def __init__(self):
+        super().__init__(1000)
+
+    def draw_layer(self):
+        level = self.get_display_level()
+        image = RiftWizard.get_image(["UI", "deploy_ok_animated"]) if level.can_stand(self.deploy_target.x, self.deploy_target.y, self.game.p1) else RiftWizard.get_image(["UI", "deploy_no_animated"])
+        deploy_frames = image.get_width() // RiftWizard.SPRITE_SIZE
+        deploy_frame = RiftWizard.idle_frame % deploy_frames
+        self.level_display.blit(image, (self.deploy_target.x * RiftWizard.SPRITE_SIZE, self.deploy_target.y * RiftWizard.SPRITE_SIZE), (deploy_frame * RiftWizard.SPRITE_SIZE, 0, RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE))
+
+    def should_draw(self):
+        return self.game.deploying and self.deploy_target
+
+class LayerSelection (Layer):
+
+    def __init__(self):
+        super().__init__(110)
+        self.selection = None
+
+    def accept_tile(self, tile):
+        if self.examine_target and (self.examine_target in [tile.unit, tile.cloud, tile.prop]):
+            self.selection = self.examine_target
+
+    def should_draw(self):
+        return self.selection
+
+    def draw_layer(self):
+        rect = (self.selection.x * RiftWizard.SPRITE_SIZE, self.selection.y * RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE, RiftWizard.SPRITE_SIZE)
+        color = (60, 60, 60)
+        pygame.draw.rect(self.level_display, color, rect)
+
+    def reset(self):
+        self.selection = None
+
+LAYER_SOULBOUND = LayerSoulbound()
+LAYER_SPELL_TARGET = LayerSpellTarget()
+LAYER_CHANNEL_TARGET = LayerChannelTarget()
+LAYER_ORB_TARGET = LayerOrbTarget()
+LAYER_THREAT = LayerThreat()
+LAYER_LOS = LayerLOS()
+LAYER_TILES = LayerTiles()
+LAYER_UNITS = LayerUnits()
+LAYER_PROPS = LayerProps()
+LAYER_EFFECTS = LayerEffects()
+LAYER_CLOUDS = LayerClouds()
+LAYER_DEPLOY = LayerDeploy()
+LAYER_SELECTION = LayerSelection()
+
+LAYER_TILES.occluded_by = [LAYER_PROPS]
+LAYER_TILES.partially_occluded_by = [LAYER_EFFECTS, LAYER_UNITS]
+LAYER_PROPS.occluded_by = [LAYER_UNITS, LAYER_EFFECTS, LAYER_CLOUDS]
+
+layers: List[Layer] = [
+    LAYER_SOULBOUND,
+    LAYER_SPELL_TARGET,
+    LAYER_CHANNEL_TARGET,
+    LAYER_ORB_TARGET,
+    LAYER_THREAT,
+    LAYER_LOS,
+    LAYER_EFFECTS,
+    LAYER_TILES,
+    LAYER_UNITS,
+    LAYER_PROPS,
+    LAYER_CLOUDS,
+    LAYER_DEPLOY,
+    LAYER_SELECTION
+]
+
+def draw_level(self):
+    if self.gameover_frames >= 8:
+        return
+
+    level = self.get_display_level()
+    self.level_display.fill((0, 0, 0))
+
+    layers.sort(key = lambda x: x.order)
+
+    for layer in layers:
+        layer.view = self
+        layer.reset()
+    
+    #Transform and drain the levels effects
+    to_remove = []
+    for effect in level.effects:
+        if not hasattr(effect, 'graphic'):
+            graphic = self.get_effect(effect)
+            if not graphic:
+                to_remove.append(effect)
+                continue
+
+            effect.graphic = graphic
+            graphic.level_effect = effect
+            # Queue buff effects, instantly play other effects
+
+            # Damage effects can replace damage effects
+            # Buff effects queue after everything
+            # Damage effects queue after buff effects
+            queued_colors = [
+                Level.Tags.Buff_Apply.color,
+                Level.Tags.Debuff_Apply.color,
+                Level.Tags.Shield_Apply.color,
+                Level.Tags.Shield_Expire.color,
+            ]
+            if hasattr(effect, 'color') and effect.color in queued_colors:
+                self.queue_effect(graphic)
+            else:
+                self.effects.append(graphic)
+            
+    # Kill sound effects
+    for effect in to_remove:
+        level.effects.remove(effect)
+
+    # Draw the board
+    self.advance_queued_effects()
+
+    if self.game.next_level:
+        self.deploy_anim_frames += 1
+        self.deploy_anim_frames = min(self.deploy_anim_frames, self.get_max_deploy_frames())
+    elif self.game.prev_next_level and self.deploy_anim_frames > 0:
+        self.deploy_anim_frames -= 1
+
+    def get_level(i, j):
+        if not self.deploy_anim_frames:
+            return self.game.cur_level
+
+        cur_radius = RiftWizard.DEPLOY_SPEED*self.deploy_anim_frames
+        if abs(i-self.game.p1.x) + abs(j-self.game.p1.y) > cur_radius:
+            return self.game.cur_level
+        else:
+            return self.game.next_level or self.game.prev_next_level
+
+
+    for i in range(0, RiftWizard.LEVEL_SIZE):
+        for j in range(0, RiftWizard.LEVEL_SIZE):
+            
+            level = get_level(i, j)
+    
+            tile = level.tiles[i][j]
+
+            for layer in layers:
+                layer.accept_tile(tile)
+
+    for layer in layers:
+        if layer.should_draw():
+            layer.draw_layer()
+
+    for e in self.effects:
+        if e.finished:
+            if hasattr(e, 'level_effect'):
+                # Sometimes this will fail if you transfer to the next level
+                # Whatever (itll be garbage collected with the level anyway)
+                if e.level_effect in self.game.cur_level.effects:
+                    self.game.cur_level.effects.remove(e.level_effect)
+                elif self.game.next_level and e.level_effect in self.game.next_level.effects:
+                    self.game.next_level.effects.remove(e.level_effect)
+
+    self.effects = [e for e in self.effects if not e.finished]
+
+    # Blit to main screen
+    pygame.transform.scale(self.whole_level_display, (self.screen.get_width(), self.screen.get_height()), self.screen)

--- a/APIs/API_DrawPanel/API_DrawPanel.py
+++ b/APIs/API_DrawPanel/API_DrawPanel.py
@@ -1,0 +1,371 @@
+from typing import List
+import Level
+import pygame
+
+####################################################
+# Importing RiftWizard.py                          |
+# Credit to trung on discord                       |
+#                                                  |
+#----------------------------------------------    |
+import inspect #                                   |
+def get_RiftWizard(): #                            |
+    # Returns the RiftWizard.py module object      |
+    for f in inspect.stack()[::-1]: #              |
+        if "file 'RiftWizard.py'" in str(f): #     |
+            return inspect.getmodule(f[0]) #       |
+	 #                                             |
+    return inspect.getmodule(f[0]) #               |
+#                                                  |
+RiftWizard = get_RiftWizard() #                    |
+#                                                  |
+#                                                  |
+####################################################
+
+class PanelItem:
+
+    def __init__(self, order):
+        self.order = order
+        self.view = None
+
+    def setup(self):
+        pass
+
+    def should_draw(self):
+        return True
+
+    def get_height(self):
+        return 0
+
+    def draw(self, cur_x, cur_y):
+        pass
+
+    def __getattr__(self, attribute):
+        # Redirect accesses to 
+        return getattr(self.view, attribute)
+
+class PanelHP(PanelItem):
+    
+    def get_height(self):
+        return self.linesize
+
+    def get_hp_color(self):
+        hpcolor = (255, 255, 255)
+        if self.game.p1.cur_hp <= 25:
+            hpcolor = (255, 0, 0)
+        return hpcolor
+
+    def draw(self, cur_x, cur_y):
+        hpcolor = self.get_hp_color()
+
+        self.draw_string("%s %d/%d" % (RiftWizard.CHAR_HEART, self.game.p1.cur_hp, self.game.p1.max_hp), self.character_display, cur_x, cur_y, color=hpcolor)
+        self.draw_string("%s" % RiftWizard.CHAR_HEART, self.character_display, cur_x, cur_y, (255, 0, 0))
+
+class PanelShield(PanelItem):
+
+    def get_height(self):
+        return self.linesize
+
+    def should_draw(self):
+        return self.game.p1.shields
+
+    def draw(self, cur_x, cur_y):
+        self.draw_string("%s %d" % (RiftWizard.CHAR_SHIELD, self.game.p1.shields), self.character_display, cur_x, cur_y)
+        self.draw_string("%s" % (RiftWizard.CHAR_SHIELD), self.character_display, cur_x, cur_y, color=RiftWizard.COLOR_SHIELD.to_tup())
+
+class PanelXP(PanelItem):
+
+    def get_height(self):
+        return self.linesize
+
+    def draw(self, cur_x, cur_y):
+        self.draw_string("SP %d" % self.game.p1.xp, self.character_display, cur_x, cur_y, color=RiftWizard.COLOR_XP)
+
+class PanelRealm(PanelItem):
+
+    def get_height(self):
+        return self.linesize
+
+    def draw(self, cur_x, cur_y):
+        self.draw_string("Realm %d" % self.game.level_num, self.character_display, cur_x, cur_y)
+
+def get_spell_color(self: Level.Spell):
+    return (255, 255, 255)
+
+def get_cost_string(self: Level.Spell):
+    cost_str = ""
+    if self.max_charges:
+        cost_str += "%2d" % self.cur_charges
+    if self.caster.cool_downs.get(self, 0) > 0:
+        cost_str += "(%d)" % self.caster.cool_downs.get(self, 0)
+    return cost_str
+
+Level.Spell.get_spell_color = get_spell_color
+Level.Spell.get_cost_string = get_cost_string
+
+class PanelSpells(PanelItem):
+
+    def get_height(self):
+        return self.linesize * (1 + len(self.game.p1.spells))
+
+    def get_spell_color(self, spell):
+        if spell == self.cur_spell:
+            cur_color = (0, 255, 0)
+        elif spell.can_pay_costs():
+            cur_color = spell.get_spell_color()
+        else:
+            cur_color = (128, 128, 128)
+        return cur_color
+
+    def get_cost_string(self, spell: Level.Spell):
+        return spell.get_cost_string()
+
+    def draw(self, cur_x, cur_y):
+        self.draw_string("Spells:", self.character_display, cur_x, cur_y)
+        cur_y += self.linesize
+
+        # Spells
+        index = 1
+        for spell in self.game.p1.spells:
+            spell_number = (index) % 10
+            mod_key = 'C' if index > 20 else 'S' if index > 10 else ''
+            hotkey_str = "%s%d" % (mod_key, spell_number)
+
+            cur_color = self.get_spell_color(spell)
+
+            cost_str = self.get_cost_string(spell)
+            
+            name_fmt = "%%-%ds" % (19-len(cost_str))
+            name_str = name_fmt % spell.name
+            fmt = "%2s  %s%s" % (hotkey_str, name_str, cost_str)
+
+            self.draw_string(fmt, self.character_display, cur_x, cur_y, cur_color, mouse_content=RiftWizard.SpellCharacterWrapper(spell), char_panel=True)
+            self.draw_spell_icon(spell, self.character_display, cur_x + 38, cur_y)
+
+            cur_y += self.linesize
+            index += 1
+
+class PanelItems(PanelItem):
+
+    def get_height(self):
+        return self.linesize * (1 + len(self.game.p1.items))
+
+    def draw(self, cur_x, cur_y):
+        self.draw_string("Items:", self.character_display, cur_x, cur_y)
+        cur_y += self.linesize
+
+        # Items
+        index = 1
+        for item in self.game.p1.items:
+
+            hotkey_str = "A%d" % (index % 10)
+
+            cur_color = (255, 255, 255)
+            if item.spell == self.cur_spell:
+                cur_color = (0, 255, 0)
+            fmt = "%2s  %-17s%2d" % (hotkey_str, item.name, item.quantity)			
+
+            self.draw_string(fmt, self.character_display, cur_x, cur_y, cur_color, mouse_content=item)
+            self.draw_spell_icon(item, self.character_display, cur_x + 38, cur_y)
+
+            cur_y += self.linesize
+            index += 1
+
+class PanelBuffs(PanelItem):
+
+    def setup(self):
+        self.status_effects = [b for b in self.game.p1.buffs if b.buff_type != RiftWizard.BUFF_TYPE_PASSIVE]
+        self.counts = {}
+        for effect in self.status_effects:
+            if effect.name not in self.counts:
+                self.counts[effect.name] = (effect, 0, 0, None)
+            _, stacks, duration, color = self.counts[effect.name]
+            stacks += 1
+            duration = max(duration, effect.turns_left)
+
+            self.counts[effect.name] = (effect, stacks, duration, effect.get_tooltip_color().to_tup())
+
+    def get_height(self):
+        return self.linesize * (2 + len(self.counts))
+
+    def should_draw(self):
+        return self.status_effects
+
+    def draw(self, cur_x, cur_y):
+        # Buffs
+        
+        cur_y += self.linesize
+        self.draw_string("Status Effects:", self.character_display, cur_x, cur_y, (255, 255, 255))
+        cur_y += self.linesize
+        for buff_name, (buff, stacks, duration, color) in self.counts.items():
+            fmt = buff_name
+            if stacks > 1:
+                fmt += ' x%d' % stacks
+            if duration:
+                fmt += ' (%d)' % duration
+            self.draw_string(fmt, self.character_display, cur_x, cur_y, color, mouse_content=buff)
+            cur_y += self.linesize
+
+class PanelSkills(PanelItem):
+    def setup(self):
+        self.skills = [b for b in self.game.p1.buffs if b.buff_type == RiftWizard.BUFF_TYPE_PASSIVE and not b.prereq]
+    
+    def get_height(self): # This is scuffed. Might want to just make draw return the height.....
+        height = self.linesize * 2
+        cur_x = self.border_margin
+        skill_x_max = self.character_display.get_width() - self.border_margin - 16
+        for skill in self.skills:
+            cur_x += 18
+            if cur_x > skill_x_max:
+                cur_x = self.border_margin
+                height += self.linesize
+        return height
+
+    def should_draw(self):
+        return self.skills
+
+    def draw(self, cur_x, cur_y):
+        cur_y += self.linesize
+
+        self.draw_string("Skills:", self.character_display, cur_x, cur_y)
+        cur_y += self.linesize
+
+        skill_x_max = self.character_display.get_width() - self.border_margin - 16
+        for skill in self.skills:
+            self.draw_spell_icon(skill, self.character_display, cur_x, cur_y)
+            cur_x += 18
+            if cur_x > skill_x_max:
+                cur_x = self.border_margin
+                cur_y += self.linesize
+
+class PanelSeperator(PanelItem):
+
+    def __init__(self, order, lines=1):
+        super().__init__(order)
+        self.lines = lines
+
+    def get_height(self):
+        return self.linesize * self.lines
+
+PANEL_HP = PanelHP(0)
+PANEL_SHIELDS = PanelShield(100)
+PANEL_XP = PanelXP(200)
+PANEL_REALM = PanelRealm(300)
+PANEL_SPELLS = PanelSpells(400)
+PANEL_ITEMS = PanelItems(500)
+PANEL_BUFFS = PanelBuffs(600)
+PANEL_SKILLS = PanelSkills(700)
+
+character_panels: List[PanelItem] = [
+    PANEL_HP,
+    PANEL_SHIELDS,
+    PANEL_XP,
+    PANEL_REALM,
+    PanelSeperator(350),
+    PANEL_SPELLS,
+    PanelSeperator(450),
+    PANEL_ITEMS,
+    PANEL_BUFFS,
+    PANEL_SKILLS
+]
+
+def character_adjust(self: RiftWizard.PyGameView, num):
+    scrollable = getattr(self, "character_panel_scrollable", False) # could __init__ hook to drop the getattr calls
+
+    if scrollable:
+        self.character_panel_scroll = getattr(self, "character_panel_scroll", 0) + num * self.linesize
+
+        self.play_sound("menu_confirm")
+
+def process_input_character(self: RiftWizard.PyGameView):
+
+    for click in self.events:
+        if click.type != pygame.MOUSEBUTTONDOWN:
+            continue
+
+        mx, my = self.get_mouse_pos()
+
+        if mx > self.h_margin:
+            continue
+
+        if self.examine_target: #Examining something should scroll the right panel only
+            continue
+
+        if click.button == pygame.BUTTON_WHEELDOWN:
+            character_adjust(self, 2)
+        
+        if click.button == pygame.BUTTON_WHEELUP:
+            character_adjust(self, -2)
+
+    pass
+
+def get_character_scroll(self: RiftWizard.PyGameView):
+    scroll = getattr(self, "character_panel_scroll", 0)
+
+    panel_height = get_total_character_height(self)
+    scrollable_height = self.character_display.get_height() - 2*self.border_margin - 3*self.linesize - 8
+    max_scroll = panel_height - scrollable_height + self.linesize * 4 # A little buffer at the end
+
+    scroll = max(scroll, 0)
+    if max_scroll > 0:
+        scroll = min(scroll, max_scroll)
+    self.character_panel_scroll = scroll
+    return scroll
+
+def get_total_character_height(self: RiftWizard.PyGameView):
+    height = 0
+
+    for panel in character_panels:
+        panel.view = self
+        panel.setup()
+        if panel.should_draw():
+            height += panel.get_height()
+
+    return height
+
+def draw_character(self: RiftWizard.PyGameView):
+
+    self.draw_panel(self.character_display)
+    
+    scrollable_width = self.character_display.get_width() - 2*self.border_margin
+    scrollable_height = self.character_display.get_height() - 2*self.border_margin - 3*self.linesize - 8
+    self.character_display.set_clip(pygame.Rect(self.border_margin, self.border_margin, scrollable_width, scrollable_height))
+
+    self.char_panel_examine_lines = {}
+
+    start_y = self.border_margin - get_character_scroll(self)
+
+    cur_x = self.border_margin
+    cur_y = start_y
+    linesize = self.linesize
+
+    character_panels.sort(key=lambda x: x.order)
+
+    for panel in character_panels:
+        panel.view = self
+        panel.setup()
+        if panel.should_draw():
+            panel.draw(cur_x, cur_y)
+            cur_y += panel.get_height()
+
+    self.character_panel_scrollable = cur_y - start_y > scrollable_height
+
+    cur_x = self.border_margin
+    cur_y = self.character_display.get_height() - self.border_margin - 3*self.linesize
+
+    self.character_display.set_clip(pygame.Rect(cur_x, cur_y, self.character_display.get_width() - self.border_margin - cur_x, self.character_display.get_height() - self.border_margin - cur_y))
+
+    menu_keybind_str = pygame.key.name(self.key_binds[RiftWizard.KEY_BIND_ABORT][0]).upper()
+    self.draw_string("Menu (%s)" % menu_keybind_str, self.character_display, cur_x, cur_y, mouse_content=RiftWizard.OPTIONS_TARGET)
+    cur_y += linesize
+
+    howto_keybind_str = pygame.key.name(self.key_binds[RiftWizard.KEY_BIND_HELP][0]).upper()
+    self.draw_string("How to Play (%s)" % howto_keybind_str, self.character_display, cur_x, cur_y, mouse_content=RiftWizard.INSTRUCTIONS_TARGET)
+    cur_y += linesize
+
+    char_keybind_str = pygame.key.name(self.key_binds[RiftWizard.KEY_BIND_CHAR][0]).upper()
+    color = self.game.p1.discount_tag.color.to_tup() if self.game.p1.discount_tag else (255, 255, 255)
+    self.draw_string("Character Sheet (%s)" % char_keybind_str, self.character_display, cur_x, cur_y, color=color, mouse_content=RiftWizard.CHAR_SHEET_TARGET)
+
+    self.character_display.set_clip(None)
+
+    self.screen.blit(self.character_display, (0, 0))

--- a/APIs/API_Spells/API_Spells.py
+++ b/APIs/API_Spells/API_Spells.py
@@ -69,7 +69,12 @@ RiftWizard.PyGameView.cast_cur_spell = cast_cur_spell #override completely
 	
 __pygameview_choose_spell_old = RiftWizard.PyGameView.choose_spell
 
-def choose_spell(self, spell):
+def choose_spell(self, spell: Level.Spell):
+	if not spell.can_pay_costs():
+		self.play_sound("menu_abort")
+		self.cast_fail_frames = RiftWizard.SPELL_FAIL_LOCKOUT_FRAMES
+		return
+
 	__pygameview_choose_spell_old(self, spell)
 	spell.multi_targets = [] #reset targets
 

--- a/APIs/API_TitleMenus/API_TitleMenus.py
+++ b/APIs/API_TitleMenus/API_TitleMenus.py
@@ -25,18 +25,18 @@ from collections import namedtuple
 
 Menu = namedtuple('Menu', 'id draw_function process_input blocks_char_sheet_and_examine')
 menus = [
-	Menu(RiftWizard.STATE_TITLE, RiftWizard.PyGameView.draw_title, RiftWizard.PyGameView.process_title_input, True),
-	Menu(RiftWizard.STATE_PICK_MODE, RiftWizard.PyGameView.draw_pick_mode, RiftWizard.PyGameView.process_pick_mode_input, True),
-	Menu(RiftWizard.STATE_PICK_TRIAL, RiftWizard.PyGameView.draw_pick_trial, RiftWizard.PyGameView.process_pick_trial_input, True),
-	Menu(RiftWizard.STATE_OPTIONS, RiftWizard.PyGameView.draw_options_menu, RiftWizard.PyGameView.process_options_input, True),
-	Menu(RiftWizard.STATE_REBIND, RiftWizard.PyGameView.draw_key_rebind, RiftWizard.PyGameView.process_key_rebind, True),
-	Menu(RiftWizard.STATE_MESSAGE, RiftWizard.PyGameView.draw_message, RiftWizard.PyGameView.process_message_input, True),
-	Menu(RiftWizard.STATE_REMINISCE, RiftWizard.PyGameView.draw_reminisce, RiftWizard.PyGameView.process_reminisce_input, True),
-	Menu(RiftWizard.STATE_LEVEL, RiftWizard.PyGameView.draw_level, lambda pygameview: None, False),
-	Menu(RiftWizard.STATE_CHAR_SHEET, RiftWizard.PyGameView.draw_char_sheet, RiftWizard.PyGameView.process_char_sheet_input, False),
-	Menu(RiftWizard.STATE_SHOP, RiftWizard.PyGameView.draw_shop, RiftWizard.PyGameView.process_shop_input, False),
-	Menu(RiftWizard.STATE_CONFIRM, RiftWizard.PyGameView.draw_confirm, RiftWizard.PyGameView.process_confirm_input, False),
-	Menu(RiftWizard.STATE_COMBAT_LOG, RiftWizard.PyGameView.draw_combat_log, RiftWizard.PyGameView.process_combat_log_input, False),
+	Menu(RiftWizard.STATE_TITLE, lambda self: RiftWizard.PyGameView.draw_title(self), lambda self: RiftWizard.PyGameView.process_title_input(self), True),
+	Menu(RiftWizard.STATE_PICK_MODE, lambda self: RiftWizard.PyGameView.draw_pick_mode(self), lambda self: RiftWizard.PyGameView.process_pick_mode_input(self), True),
+	Menu(RiftWizard.STATE_PICK_TRIAL, lambda self: RiftWizard.PyGameView.draw_pick_trial(self), lambda self: RiftWizard.PyGameView.process_pick_trial_input(self), True),
+	Menu(RiftWizard.STATE_OPTIONS, lambda self: RiftWizard.PyGameView.draw_options_menu(self), lambda self: RiftWizard.PyGameView.process_options_input(self), True),
+	Menu(RiftWizard.STATE_REBIND, lambda self: RiftWizard.PyGameView.draw_key_rebind(self), lambda self: RiftWizard.PyGameView.process_key_rebind(self), True),
+	Menu(RiftWizard.STATE_MESSAGE, lambda self: RiftWizard.PyGameView.draw_message(self), lambda self: RiftWizard.PyGameView.process_message_input(self), True),
+	Menu(RiftWizard.STATE_REMINISCE, lambda self: RiftWizard.PyGameView.draw_reminisce(self), lambda self: RiftWizard.PyGameView.process_reminisce_input(self), True),
+	Menu(RiftWizard.STATE_LEVEL, lambda self: RiftWizard.PyGameView.draw_level(self), lambda self: None, False),
+	Menu(RiftWizard.STATE_CHAR_SHEET, lambda self: RiftWizard.PyGameView.draw_char_sheet(self), lambda self: RiftWizard.PyGameView.process_char_sheet_input(self), False),
+	Menu(RiftWizard.STATE_SHOP, lambda self: RiftWizard.PyGameView.draw_shop(self), lambda self: RiftWizard.PyGameView.process_shop_input(self), False),
+	Menu(RiftWizard.STATE_CONFIRM, lambda self: RiftWizard.PyGameView.draw_confirm(self), lambda self: RiftWizard.PyGameView.process_confirm_input(self), False),
+	Menu(RiftWizard.STATE_COMBAT_LOG, lambda self: RiftWizard.PyGameView.draw_combat_log(self), lambda self: RiftWizard.PyGameView.process_combat_log_input(self), False),
 ]
 menu_transition_overrides = []
 

--- a/APIs/API_TitleMenus/API_TitleMenus.py
+++ b/APIs/API_TitleMenus/API_TitleMenus.py
@@ -26,18 +26,18 @@ import mods.API_Universal.APIs.API_DrawPanel.API_DrawPanel as API_DrawPanel
 
 Menu = namedtuple('Menu', 'id draw_function process_input blocks_char_sheet_and_examine')
 menus = [
-	Menu(RiftWizard.STATE_TITLE, lambda self: RiftWizard.PyGameView.draw_title(self), lambda self: RiftWizard.PyGameView.process_title_input(self), True),
-	Menu(RiftWizard.STATE_PICK_MODE, lambda self: RiftWizard.PyGameView.draw_pick_mode(self), lambda self: RiftWizard.PyGameView.process_pick_mode_input(self), True),
-	Menu(RiftWizard.STATE_PICK_TRIAL, lambda self: RiftWizard.PyGameView.draw_pick_trial(self), lambda self: RiftWizard.PyGameView.process_pick_trial_input(self), True),
-	Menu(RiftWizard.STATE_OPTIONS, lambda self: RiftWizard.PyGameView.draw_options_menu(self), lambda self: RiftWizard.PyGameView.process_options_input(self), True),
-	Menu(RiftWizard.STATE_REBIND, lambda self: RiftWizard.PyGameView.draw_key_rebind(self), lambda self: RiftWizard.PyGameView.process_key_rebind(self), True),
-	Menu(RiftWizard.STATE_MESSAGE, lambda self: RiftWizard.PyGameView.draw_message(self), lambda self: RiftWizard.PyGameView.process_message_input(self), True),
-	Menu(RiftWizard.STATE_REMINISCE, lambda self: RiftWizard.PyGameView.draw_reminisce(self), lambda self: RiftWizard.PyGameView.process_reminisce_input(self), True),
-	Menu(RiftWizard.STATE_LEVEL, lambda self: RiftWizard.PyGameView.draw_level(self), lambda self: None, False),
-	Menu(RiftWizard.STATE_CHAR_SHEET, lambda self: RiftWizard.PyGameView.draw_char_sheet(self), lambda self: RiftWizard.PyGameView.process_char_sheet_input(self), False),
-	Menu(RiftWizard.STATE_SHOP, lambda self: RiftWizard.PyGameView.draw_shop(self), lambda self: RiftWizard.PyGameView.process_shop_input(self), False),
-	Menu(RiftWizard.STATE_CONFIRM, lambda self: RiftWizard.PyGameView.draw_confirm(self), lambda self: RiftWizard.PyGameView.process_confirm_input(self), False),
-	Menu(RiftWizard.STATE_COMBAT_LOG, lambda self: RiftWizard.PyGameView.draw_combat_log(self), lambda self: RiftWizard.PyGameView.process_combat_log_input(self), False),
+	Menu(RiftWizard.STATE_TITLE, lambda pygameview: RiftWizard.PyGameView.draw_title(pygameview), lambda pygameview: RiftWizard.PyGameView.process_title_input(pygameview), True),
+	Menu(RiftWizard.STATE_PICK_MODE, lambda pygameview: RiftWizard.PyGameView.draw_pick_mode(pygameview), lambda pygameview: RiftWizard.PyGameView.process_pick_mode_input(pygameview), True),
+	Menu(RiftWizard.STATE_PICK_TRIAL, lambda pygameview: RiftWizard.PyGameView.draw_pick_trial(pygameview), lambda pygameview: RiftWizard.PyGameView.process_pick_trial_input(pygameview), True),
+	Menu(RiftWizard.STATE_OPTIONS, lambda pygameview: RiftWizard.PyGameView.draw_options_menu(pygameview), lambda pygameview: RiftWizard.PyGameView.process_options_input(pygameview), True),
+	Menu(RiftWizard.STATE_REBIND, lambda pygameview: RiftWizard.PyGameView.draw_key_rebind(pygameview), lambda pygameview: RiftWizard.PyGameView.process_key_rebind(pygameview), True),
+	Menu(RiftWizard.STATE_MESSAGE, lambda pygameview: RiftWizard.PyGameView.draw_message(pygameview), lambda pygameview: RiftWizard.PyGameView.process_message_input(pygameview), True),
+	Menu(RiftWizard.STATE_REMINISCE, lambda pygameview: RiftWizard.PyGameView.draw_reminisce(pygameview), lambda pygameview: RiftWizard.PyGameView.process_reminisce_input(pygameview), True),
+	Menu(RiftWizard.STATE_LEVEL, lambda pygameview: RiftWizard.PyGameView.draw_level(pygameview), lambda pygameview: None, False),
+	Menu(RiftWizard.STATE_CHAR_SHEET, lambda pygameview: RiftWizard.PyGameView.draw_char_sheet(pygameview), lambda pygameview: RiftWizard.PyGameView.process_char_sheet_input(pygameview), False),
+	Menu(RiftWizard.STATE_SHOP, lambda pygameview: RiftWizard.PyGameView.draw_shop(pygameview), lambda pygameview: RiftWizard.PyGameView.process_shop_input(pygameview), False),
+	Menu(RiftWizard.STATE_CONFIRM, lambda pygameview: RiftWizard.PyGameView.draw_confirm(pygameview), lambda pygameview: RiftWizard.PyGameView.process_confirm_input(pygameview), False),
+	Menu(RiftWizard.STATE_COMBAT_LOG, lambda pygameview: RiftWizard.PyGameView.draw_combat_log(pygameview), lambda pygameview: RiftWizard.PyGameView.process_combat_log_input(pygameview), False),
 ]
 menu_transition_overrides = []
 

--- a/APIs/API_TitleMenus/API_TitleMenus.py
+++ b/APIs/API_TitleMenus/API_TitleMenus.py
@@ -21,6 +21,7 @@ RiftWizard = get_RiftWizard() #                    |
 
 
 from collections import namedtuple
+import mods.API_Universal.APIs.API_DrawPanel.API_DrawPanel as API_DrawPanel
 
 
 Menu = namedtuple('Menu', 'id draw_function process_input blocks_char_sheet_and_examine')
@@ -61,6 +62,9 @@ def on_run_process_input(self):
 	prev_state = self.state
 	cur_menu.process_input(self)
 	new_state = self.state
+
+	if new_state == prev_state and not cur_menu.blocks_char_sheet_and_examine:
+		API_DrawPanel.process_input_character(self)
 
 	global menu_transition_overrides
 	state_transition_overrides = [override for (fro, to, override, condition) in menu_transition_overrides if condition(self) and fro == prev_state and to == new_state]

--- a/APIs/API_Turns/API_Turns.py
+++ b/APIs/API_Turns/API_Turns.py
@@ -1,6 +1,12 @@
 import Level
+import mods.API_Universal.Libraries.Library_QuickPatch.Library_QuickPatch as Library_QuickPatch
 import time, random
 from typing import List
+
+def unit_init(self, *args, **kwargs):
+    self.haste = 0
+
+Library_QuickPatch.patch_init(Level.Unit, unit_init)
 
 class TurnAdvancer:
 
@@ -54,7 +60,7 @@ class TurnUnits(TurnAdvancerSplit):
                     self.level.is_awaiting_input = True
                     yield
                 finished_advance = unit.advance()
-                if getattr(unit, 'haste', 0):
+                if unit.haste and unit.is_alive():
                     finished_advance = False
                     unit.haste -= 1
                 

--- a/APIs/API_Turns/API_Turns.py
+++ b/APIs/API_Turns/API_Turns.py
@@ -1,0 +1,56 @@
+import Level
+import time, random
+
+def advance_spells(self: Level.Level):
+    while self.can_advance_spells():
+        yield self.advance_spells()
+
+def iter_frame(self: Level.Level, mark_turn_end=False):
+    # An iterator representing the order of turns for all game objects
+    while True:
+        # Yield once per iteration if there are no units to prevent infinite loop
+        if not self.units:
+            yield
+        self.turn_no += 1
+        if any(u.team != Level.TEAM_PLAYER for u in self.units):
+            self.next_log_turn()
+            self.combat_log.debug("Level %d, Turn %d begins." % (self.level_no, self.turn_no))
+        # Cache unit list here to enforce summoning delay
+        turn_units = list(self.units)
+        for is_player_turn in [True, False]:
+            clouds = [cloud for cloud in self.clouds if cloud.owner.is_player_controlled == is_player_turn]
+            if clouds:
+                for cloud in clouds:
+                    if cloud.is_alive:
+                        cloud.advance()
+                yield from advance_spells(self)
+            units = [unit for unit in turn_units if unit.is_player_controlled == is_player_turn]
+            random.shuffle(units)
+            for unit in units:
+                if not unit.is_alive():
+                    continue
+                unit.pre_advance()
+                finished_advance = False
+                while not finished_advance:
+                    if unit.is_player_controlled and not unit.is_stunned() and not self.requested_action:
+                        self.is_awaiting_input = True
+                        yield
+                    finished_advance = unit.advance()
+                    
+                #yield
+                yield from advance_spells(self)
+                # Advance buffs after advancing spells
+                unit.advance_buffs()
+                yield from advance_spells(self)
+                self.frame_units_moved += 1
+                
+                # Yield if the current advance frame is aboive the advance time budget
+                if time.time() - self.frame_start_time > Level.MAX_ADVANCE_TIME:
+                    yield
+        # Advance all props similtaneously
+        for prop in list(self.props):
+            prop.advance()
+        # In the unlikely event that that created effects, advance them
+        yield from advance_spells(self)
+        if not Level.visual_mode:
+            yield True

--- a/APIs/API_Turns/API_Turns.py
+++ b/APIs/API_Turns/API_Turns.py
@@ -1,9 +1,109 @@
 import Level
 import time, random
+from typing import List
+
+class TurnAdvancer:
+
+    def __init__(self, order):
+        self.order = order
+        self.level = None
+
+    def setup(self):
+        pass
+
+    def advance(self):
+        yield from ()
+
+    def __getattr__(self, attribute):
+        # Redirect accesses to 
+        return getattr(self.level, attribute)
+
+class TurnAdvancerSplit(TurnAdvancer):
+
+    def __init__(self, order, splits):
+        super().__init__(order)
+        self.splits = splits
+
+    def advance(self):
+        for split in self.splits:
+            yield from self.advance_split(split)
+
+    def advance_split(self, split):
+        yield from ()
+
+class TurnUnits(TurnAdvancerSplit):
+
+    def __init__(self, order):
+        super().__init__(order, [True, False])
+
+    def setup(self):
+        # Store units to enforce summoning sickness
+        self.turn_units = list(self.units)
+
+    def advance_split(self, is_player_turn):
+        units = [unit for unit in self.turn_units if unit.is_player_controlled == is_player_turn]
+        random.shuffle(units)
+
+        for unit in units:
+            if not unit.is_alive():
+                continue
+            unit.pre_advance()
+            finished_advance = False
+            while not finished_advance:
+                if unit.is_player_controlled and not unit.is_stunned() and not self.requested_action:
+                    self.level.is_awaiting_input = True
+                    yield
+                finished_advance = unit.advance()
+                if getattr(unit, 'haste', 0):
+                    finished_advance = False
+                    unit.haste -= 1
+                
+                #yield
+                yield from advance_spells(self)
+            # Advance buffs after advancing spells
+            unit.advance_buffs()
+            yield from advance_spells(self)
+            self.level.frame_units_moved += 1
+            
+            # Yield if the current advance frame is aboive the advance time budget
+            if time.time() - self.frame_start_time > Level.MAX_ADVANCE_TIME:
+                yield
+
+class TurnClouds(TurnAdvancerSplit):
+
+    def __init__(self, order):
+        super().__init__(order, [True, False])
+
+    def setup(self):
+        pass
+
+    def advance_split(self, is_player_turn):
+        clouds = [cloud for cloud in self.clouds if cloud.owner.is_player_controlled == is_player_turn]
+        if clouds:
+            for cloud in clouds:
+                if cloud.is_alive:
+                    cloud.advance()
+            yield from advance_spells(self)
+
+class TurnProps(TurnAdvancer):
+    def advance(self):
+        for prop in list(self.props):
+            prop.advance()
+        yield from advance_spells(self)
 
 def advance_spells(self: Level.Level):
     while self.can_advance_spells():
         yield self.advance_spells()
+
+TURN_CLOUDS = TurnClouds(100)
+TURN_UNITS = TurnUnits(200)
+TURN_PROPS = TurnProps(300)
+
+turn_advancers: List[TurnAdvancer] = [
+    TURN_CLOUDS,
+    TURN_UNITS,
+    TURN_PROPS
+]
 
 def iter_frame(self: Level.Level, mark_turn_end=False):
     # An iterator representing the order of turns for all game objects
@@ -15,42 +115,12 @@ def iter_frame(self: Level.Level, mark_turn_end=False):
         if any(u.team != Level.TEAM_PLAYER for u in self.units):
             self.next_log_turn()
             self.combat_log.debug("Level %d, Turn %d begins." % (self.level_no, self.turn_no))
-        # Cache unit list here to enforce summoning delay
-        turn_units = list(self.units)
-        for is_player_turn in [True, False]:
-            clouds = [cloud for cloud in self.clouds if cloud.owner.is_player_controlled == is_player_turn]
-            if clouds:
-                for cloud in clouds:
-                    if cloud.is_alive:
-                        cloud.advance()
-                yield from advance_spells(self)
-            units = [unit for unit in turn_units if unit.is_player_controlled == is_player_turn]
-            random.shuffle(units)
-            for unit in units:
-                if not unit.is_alive():
-                    continue
-                unit.pre_advance()
-                finished_advance = False
-                while not finished_advance:
-                    if unit.is_player_controlled and not unit.is_stunned() and not self.requested_action:
-                        self.is_awaiting_input = True
-                        yield
-                    finished_advance = unit.advance()
-                    
-                #yield
-                yield from advance_spells(self)
-                # Advance buffs after advancing spells
-                unit.advance_buffs()
-                yield from advance_spells(self)
-                self.frame_units_moved += 1
-                
-                # Yield if the current advance frame is aboive the advance time budget
-                if time.time() - self.frame_start_time > Level.MAX_ADVANCE_TIME:
-                    yield
-        # Advance all props similtaneously
-        for prop in list(self.props):
-            prop.advance()
-        # In the unlikely event that that created effects, advance them
-        yield from advance_spells(self)
+
+        turn_advancers.sort(key=lambda x: x.order)
+        for turn_advancer in turn_advancers:
+            turn_advancer.level = self
+            turn_advancer.setup()
+            yield from turn_advancer.advance()
+        
         if not Level.visual_mode:
             yield True

--- a/LevelOverrides.py
+++ b/LevelOverrides.py
@@ -1,5 +1,6 @@
 import Level
 import mods.API_Universal.APIs.API_Disrupt.API_Disrupt as API_Disrupt
+import mods.API_Universal.APIs.API_Turns.API_Turns as API_Turns
 
 
 # ----------------------------------------------------------------------------------------+
@@ -22,6 +23,7 @@ def portal_disrupt(self, caster):
 	API_Disrupt.disrupt_default(self, caster)
 Level.Portal.disrupt = portal_disrupt
 
+Level.Level.iter_frame = API_Turns.iter_frame
 
 if API_Multiplayer:
 	Level.Level.iter_frame = API_Multiplayer.Level_iter_frame

--- a/Libraries/Library_QuickPatch/Library_QuickPatch.py
+++ b/Libraries/Library_QuickPatch/Library_QuickPatch.py
@@ -1,0 +1,10 @@
+from typing import Callable, TypeVar
+
+T = TypeVar('T')
+
+def patch_init(cls: T, init: Callable[[T], None]):
+    old_init = cls.__init__
+    def new_init(self, *args, **kwargs):
+        old_init(self, *args, **kwargs)
+        init(self, *args, **kwargs)
+    cls.__init__ = new_init

--- a/RiftWizardOverrides.py
+++ b/RiftWizardOverrides.py
@@ -139,7 +139,8 @@ def get_repeatable_keys(self):
 		RiftWizard.KEY_BIND_UP_RIGHT,
 		RiftWizard.KEY_BIND_UP_LEFT,
 		RiftWizard.KEY_BIND_DOWN_RIGHT,
-		RiftWizard.KEY_BIND_DOWN_LEFT
+		RiftWizard.KEY_BIND_DOWN_LEFT,
+		RiftWizard.KEY_BIND_PASS
 	]
 	
 	return [key for kb in repeatable_keybinds for key in self.key_binds[kb]]
@@ -254,6 +255,7 @@ def run(self):
 			self.process_examine_panel_input()
 
 		advanced = False
+		delay_menu_process = False
 		if self.game and self.state == RiftWizard.STATE_LEVEL:
 			level = self.get_display_level()
 			# If any creatuers are doing a cast anim, do not process effects or spells or later moves
@@ -276,7 +278,10 @@ def run(self):
 				self.deploy_target = Level.Point(self.game.p1.x, self.game.p1.y)
 				self.tab_targets = [t for t in self.game.next_level.iter_tiles() if isinstance(t.prop, Level.Portal)]
 
+			prev_state = self.state
 			self.process_level_input()
+			if prev_state != self.state:
+				delay_menu_process = True
 
 			if self.game and self.game.victory_evt:
 				self.game.victory_evt = False
@@ -298,7 +303,7 @@ def run(self):
 						self.game.advance()
 				# Continually advance everything in super turbo, attemptng to do full turn in 1 go
 				if self.options['spell_speed'] == 3:
-					while not self.game.is_awaiting_input():
+					while not self.game.is_awaiting_input() and not self.game.gameover and not self.game.victory:
 						self.game.advance()
 
 				# Check triggers
@@ -308,10 +313,9 @@ def run(self):
 					else:
 						self.open_shop(RiftWizard.SHOP_TYPE_SHOP)
 
-
-		# here's wehre I add code for input for custom menus
-		API_TitleMenus.on_run_process_input(self)
-
+		if not delay_menu_process:
+			# here's wehre I add code for input for custom menus
+			API_TitleMenus.on_run_process_input(self)
 		
 		# If not examining anything- examine cur spell if possible
 		if not self.examine_target and self.cur_spell and self.cur_spell.show_tt:

--- a/RiftWizardOverrides.py
+++ b/RiftWizardOverrides.py
@@ -285,7 +285,7 @@ def run(self):
 
 			prev_state = self.state
 			self.process_level_input()
-			if prev_state != self.state:
+			if prev_state != self.state: # If we're opening a menu from the Level, delay menu process for one tick, fixes ESC and charsheet processing
 				delay_menu_process = True
 
 			if self.game and self.game.victory_evt:

--- a/RiftWizardOverrides.py
+++ b/RiftWizardOverrides.py
@@ -28,6 +28,7 @@ import mods.API_Universal.APIs.API_OptionsMenu.API_OptionsMenu as API_OptionsMen
 import mods.API_Universal.APIs.API_TitleMenus.API_TitleMenus as API_TitleMenus
 import mods.API_Universal.APIs.API_Music.API_Music as API_Music
 import mods.API_Universal.APIs.API_Spells.API_Spells as API_Spells
+import mods.API_Universal.APIs.API_DrawLevel.API_DrawLevel as API_DrawLevel
 import mods.API_Universal.EventSystem as EventSystem
 
 # ----------------------------------------------------------------------------------------+
@@ -147,6 +148,7 @@ def get_repeatable_keys(self):
 		
 RiftWizard.PyGameView.get_repeatable_keys = get_repeatable_keys
 
+RiftWizard.PyGameView.draw_level = API_DrawLevel.draw_level
 
 import gc
 import time

--- a/RiftWizardOverrides.py
+++ b/RiftWizardOverrides.py
@@ -29,6 +29,7 @@ import mods.API_Universal.APIs.API_TitleMenus.API_TitleMenus as API_TitleMenus
 import mods.API_Universal.APIs.API_Music.API_Music as API_Music
 import mods.API_Universal.APIs.API_Spells.API_Spells as API_Spells
 import mods.API_Universal.APIs.API_DrawLevel.API_DrawLevel as API_DrawLevel
+import mods.API_Universal.APIs.API_DrawPanel.API_DrawPanel as API_DrawPanel
 import mods.API_Universal.EventSystem as EventSystem
 
 # ----------------------------------------------------------------------------------------+
@@ -149,6 +150,8 @@ def get_repeatable_keys(self):
 RiftWizard.PyGameView.get_repeatable_keys = get_repeatable_keys
 
 RiftWizard.PyGameView.draw_level = API_DrawLevel.draw_level
+
+RiftWizard.PyGameView.draw_character = API_DrawPanel.draw_character
 
 import gc
 import time


### PR DESCRIPTION
- Fixes Esc not working
- Fixes Char Sheet button taking you straight to the spell list
- Fixes method patches to menu drawing and menu input processing not applying
- Fixes spells being selectable even if the player can't pay the cost, causing an assertion failure when actually trying to cast the spell
- Fixes Spell::quick_cast to actually work and not consume a turn when casting the spell
- Adds API_DrawLevel, for modifying how levels are drawn
- Adds API_DrawPanel, for modifying how the left character panel is drawn
- Adds API_Turns, for modifying turn order
- Adds Unit::haste, to make no action consume a turn until the unit runs out of haste
- Changes the left panel to be scrollable by hovering over it and using the mouse wheel