### PR TITLE
fix for broken ShrinesOverrides

### DIFF
--- a/ShrinesOverrides.py
+++ b/ShrinesOverrides.py
@@ -1,7 +1,10 @@
 
 import Shrines as Shrines
+import LevelGen as LevelGen
 import mods.API_Universal.APIs.API_LevelGenProps.API_LevelGenProps as API_LevelGenProps
 import mods.API_Universal.APIs.API_Spells.API_Spells as API_Spells
 
 Shrines.roll_shrine = API_LevelGenProps.roll_shrine
 Shrines.random_spell_tag = API_Spells.random_spell_tag
+LevelGen.roll_shrine = API_LevelGenProps.roll_shrine
+LevelGen.random_spell_tag = API_Spells.random_spell_tag


### PR DESCRIPTION
LevelGen.roll_shrine / LevelGen.random_spell_tag still pointed at the original one from Shrines, meaning that the code from the API was never executed by LevelGen.