### PR TITLE
Speedups in API_DrawLevel

### DIFF
--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -167,13 +167,37 @@ class LayerTiles (Layer):
         self.occlusion.add((tile.x, tile.y))
 
     def draw_layer(self):
+        # much faster to batch the blits together
+        draw_tiles = []
+
         for tile in self.tiles:
             should_draw_tile = True
             if self.is_occluded(tile.x, tile.y, tile=tile):
                 should_draw_tile = False
             if should_draw_tile:
                 partial_occulde = self.is_partially_occluded(tile.x, tile.y)
-                self.draw_tile(tile, partial_occulde=partial_occulde)
+                draw_tiles.append(self.build_draw_tile(tile, partial_occulde=partial_occulde))
+
+        self.level_display.blits(draw_tiles)
+    
+    def build_draw_tile(self, tile, partial_occulde=False):
+        x = tile.x * RiftWizard.SPRITE_SIZE
+        y = tile.y * RiftWizard.SPRITE_SIZE
+        
+        if not tile.sprites:
+            tile.sprites = [None, None]
+
+        if not partial_occulde:
+            if not tile.sprites[0]:
+                tile.sprites[0] = self.make_tile_sprite(tile, 0)
+            image = tile.sprites[0]
+        else:
+            if not tile.sprites[1]:
+                tile.sprites[1] = self.make_tile_sprite(tile, 1)
+            image = tile.sprites[1]
+        
+        return (image, (x,y))
+
 
     def reset(self):
         self.tiles.clear()

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -53,7 +53,10 @@ class Layer:
 
     ## Checks whether a tile on this layer is occluded by another layer
     def is_occluded(self, x, y):
-        return any(layer.occludes(x, y) for layer in self.occluded_by)
+        for layer in self.occluded_by:
+            if layer.occludes(x, y):
+                return True
+        return False
 
     def __getattr__(self, attribute):
         # Redirect accesses to 
@@ -182,7 +185,10 @@ class LayerTiles (Layer):
         return super().is_occluded(x, y)
 
     def is_partially_occluded(self, x, y):
-        return any(layer.occludes(x, y) for layer in self.partially_occluded_by)
+        for layer in self.partially_occluded_by:
+            if layer.occludes(x, y):
+                return True
+        return False
 
     def occludes(self, x, y):
         return (x, y) in self.occlusion

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -327,7 +327,7 @@ def unit_build_blit(self, x, y):
         to_blit.append((to_draw, (x, y)))
     
     if self.boss_glow:
-        glow_image = self.sheet.get_glow_frame(self.anim, self.anim_frame, Color(255, 80, 0), self.unit.sprite.face_left, outline=True)
+        glow_image = self.sheet.get_glow_frame(self.anim, self.anim_frame, RiftWizard.Color(255, 80, 0), self.unit.sprite.face_left, outline=True)
         to_blit.append((glow_image, (x, y)))
     
     if self.hit_flash_colors:
@@ -456,7 +456,7 @@ class LayerUnits (Layer):
         
             to_blit.append((image, (buff_x, y+1), source_rect))
         else:
-            color = b.color if b.color else Color(255, 255, 255)
+            color = b.color if b.color else RiftWizard.Color(255, 255, 255)
             rects.append((color.to_tup(), (buff_x, y+1, 3, 3)))
         
         return (to_blit, rects)

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -387,7 +387,6 @@ class LayerUnits (Layer):
         
         for color,rect in rects:
             pygame.draw.rect(self.view.level_display, color, rect)
-        # TODO DRAW RECTS HERE FIXME
 
     def build_draw_unit(self, u):
         x = u.x * RiftWizard.SPRITE_SIZE

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -1,4 +1,5 @@
 import Level
+import LevelGen
 import CommonContent
 #import RiftWizard
 import Spells
@@ -154,17 +155,20 @@ class LayerEffects (Layer):
     def occludes(self, x, y):
         return (x, y) in self.occlusion
 
+TILE_TABLE_WIDTH = LevelGen.LEVEL_SIZE
+TILE_TABLE_SIZE = TILE_TABLE_WIDTH * TILE_TABLE_WIDTH
 class LayerTiles (Layer):
 
     def __init__(self):
         super().__init__(100)
-        self.tiles: List[Level.Tile] = []
+        self.tiles: List[Level.Tile] = [None] * TILE_TABLE_SIZE
         self.partially_occluded_by: List[Layer] = []
-        self.occlusion: Set = set()
+        self.occlusion : List[bool] = [False] * TILE_TABLE_SIZE
 
     def accept_tile(self, tile):
-        self.tiles.append(tile)
-        self.occlusion.add((tile.x, tile.y))
+        index = tile.x + tile.y * TILE_TABLE_WIDTH
+        self.tiles[index] = tile
+        self.occlusion[index] = True
 
     def draw_layer(self):
         # much faster to batch the blits together
@@ -200,8 +204,9 @@ class LayerTiles (Layer):
 
 
     def reset(self):
-        self.tiles.clear()
-        self.occlusion.clear()
+        for index in range(TILE_TABLE_SIZE):
+            self.occlusion[index] = False
+            self.tiles[index] = None
 
     def is_occluded(self, x, y, tile=None):
         if tile and not tile.is_chasm and LAYER_UNITS.occludes(x,y): # Tiles are also occluded by units if they're not chasmas
@@ -222,7 +227,7 @@ class LayerTiles (Layer):
         return False
 
     def occludes(self, x, y):
-        return (x, y) in self.occlusion
+        return self.occlusion[tile.x + tile.y * TILE_TABLE_WIDTH]
 
 class LayerProps (Layer):
 

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -444,9 +444,7 @@ class LayerUnits (Layer):
         
         b = status_effects[buff_index]
 
-        image = None
-        if not b.asset:
-            image = RiftWizard.get_image(b.asset)
+        image = RiftWizard.get_image(b.asset)
         
         if image:
             num_frames = image.get_width() // RiftWizard.STATUS_ICON_SIZE

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -444,18 +444,20 @@ class LayerUnits (Layer):
         
         b = status_effects[buff_index]
 
+        image = None
         if not b.asset:
-            color = b.color if b.color else Color(255, 255, 255)
-            rects.append((color.to_tup(), (buff_x, y+1, 3, 3)))
-        else:
             image = RiftWizard.get_image(b.asset)
-            
+        
+        if image:
             num_frames = image.get_width() // RiftWizard.STATUS_ICON_SIZE
 
             frame_num = RiftWizard.cloud_frame_clock // RiftWizard.STATUS_SUBFRAMES % num_frames 
             source_rect = (RiftWizard.STATUS_ICON_SIZE*frame_num, 0, RiftWizard.STATUS_ICON_SIZE, RiftWizard.STATUS_ICON_SIZE)
-            
+        
             to_blit.append((image, (buff_x, y+1), source_rect))
+        else:
+            color = b.color if b.color else Color(255, 255, 255)
+            rects.append((color.to_tup(), (buff_x, y+1, 3, 3)))
         
         return (to_blit, rects)
 

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -206,7 +206,14 @@ class LayerTiles (Layer):
     def is_occluded(self, x, y, tile=None):
         if tile and not tile.is_chasm and LAYER_UNITS.occludes(x,y): # Tiles are also occluded by units if they're not chasmas
             return True
-        return super().is_occluded(x, y)
+        
+        # this used to be: return super().is_occluded(x, y)
+        # i'm shocked that this matters that much but it saves a full
+        # millisecond per frame on average
+        for layer in self.occluded_by:
+            if layer.occludes(x, y):
+                return True
+        return False
 
     def is_partially_occluded(self, x, y):
         for layer in self.partially_occluded_by:

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -449,16 +449,14 @@ class LayerUnits (Layer):
             color = b.color if b.color else Color(255, 255, 255)
             rects.append((color.to_tup(), (buff_x, y+1, 3, 3)))
         else:
-            # cache the image instead of doing all the stuff get_image does every time
-            if not hasattr(b, 'image'):
-                b.image = RiftWizard.get_image(b.asset)
+            image = RiftWizard.get_image(b.asset)
             
-            num_frames = b.image.get_width() // RiftWizard.STATUS_ICON_SIZE
+            num_frames = image.get_width() // RiftWizard.STATUS_ICON_SIZE
 
             frame_num = RiftWizard.cloud_frame_clock // RiftWizard.STATUS_SUBFRAMES % num_frames 
             source_rect = (RiftWizard.STATUS_ICON_SIZE*frame_num, 0, RiftWizard.STATUS_ICON_SIZE, RiftWizard.STATUS_ICON_SIZE)
             
-            to_blit.append((b.image, (buff_x, y+1), source_rect))
+            to_blit.append((image, (buff_x, y+1), source_rect))
         
         return (to_blit, rects)
 

--- a/APIs/API_DrawLevel/API_DrawLevel.py
+++ b/APIs/API_DrawLevel/API_DrawLevel.py
@@ -225,7 +225,7 @@ class LayerTiles (Layer):
             if not (tile.x, tile.y) in occluded:
                 draw_tiles.append(self.build_draw_tile(tile, partial_occlude=(tile.x, tile.y) in partially_occluded))
 
-        self.level_display.blits(draw_tiles)
+        self.view.level_display.blits(draw_tiles)
     
     def build_draw_tile(self, tile, partial_occlude=False):
         x = tile.x * RiftWizard.SPRITE_SIZE


### PR DESCRIPTION
I moved some code out of RiftWizard.py and Level.py for this. we discussed some of the speedups numerically in discord but if you need i can try to re-measure and give you numbers here

the big changes:
- many `.blit` calls have been deferred to a batched `.blits`
- added `Layer.get_occluding_set()` function used, instead of manually querying each layer separately